### PR TITLE
Consistent package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "type": "module",
+  "private": true,
   "dependencies": {
-    "@fastly/js-compute": "^3.32.2"
+    "@fastly/js-compute": "^3.33.2"
   },
   "devDependencies": {
     "@babel/core": "^7.26.9",
     "@babel/preset-react": "^7.26.3",
-    "@fastly/cli": "^10.18.0",
+    "@fastly/cli": "^11.0.0",
     "babel-loader": "^9.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
This PR makes package.json consistent across the various JavaScript (TypeScript) starter kits.

1. As this is a template, removes fields that we would not want downstream projects to inherit if they were set:
   * package name, author, bugs, homepage, repository, license, version

2. As the package created from the template is an application:
   * sets private: true
   * removes main if it was set

3. Removes any engine requirement, as it is unneeded (and has been removed from js-compute since 3.14.0 as well).

4. Updates @fastly/cli to version ^11.0.0 (latest major release) and @fastly/js-compute to ^3.33.2 (includes latest crash fix)
   * if package depends on webpack, updates it to ^5.98.0, which includes a security fix

5. Places `dependencies`, `devDependencies`, `scripts` consistently in this order.
