### PR TITLE
chore: bump @fastly/cli to v14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.9",
     "@babel/preset-react": "^7.26.3",
-    "@fastly/cli": "^13.0.0",
+    "@fastly/cli": "^14.0.0",
     "babel-loader": "^9.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
Automated dependency bump across starter kits.